### PR TITLE
automerge stable dependencies

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,26 @@
+name: automerge
+on: pull_request
+    
+permissions:
+  contents: write
+  pull-requests: write
+    
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.6.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{
+          contains(steps.metadata.outputs.dependency-names, 'pipeworks') ||
+          contains(steps.metadata.outputs.dependency-names, 'technic') ||
+          contains(steps.metadata.outputs.dependency-names, 'mods/mtg')}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This PR enables automerge (with approval) of the following dependencies:
* `pipeworks`
* `technic`
* `mods/mtg`

Working example: https://github.com/mesecons-lab/mesecons_lab/pull/337

Might be good to add a branch protection to just allow passed builds: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches