### PR TITLE
Use correct engine image in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,5 @@ jobs:
         submodules: recursive
     - name: test
       run: docker-compose up --exit-code-from testserver
+      env:
+        ENGINE_IMAGE: ${{ matrix.ENGINE_IMAGE }}


### PR DESCRIPTION
The wrong docker image was being used in tests (see the first few log messages for "tests" in https://github.com/mt-mods/dreambuilder_game/actions/runs/7703729978/job/20994681582)