### PR TITLE
removes cool trees properly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -271,6 +271,9 @@
 [submodule "mods/invsaw"]
 	path = mods/invsaw
 	url = https://github.com/minetest-mirrors/invsaw.git
+[submodule "mods/cool_trees"]
+	path = mods/cool_trees
+	url = https://github.com/runsy/cool_trees/
 [submodule "mods/cblocks"]
 	path = mods/cblocks
 	url = https://github.com/minetest-mirrors/cblocks.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -271,9 +271,6 @@
 [submodule "mods/invsaw"]
 	path = mods/invsaw
 	url = https://github.com/minetest-mirrors/invsaw.git
-[submodule "mods/cool_trees"]
-	path = mods/cool_trees
-	url = https://github.com/runsy/cool_trees/
 [submodule "mods/cblocks"]
 	path = mods/cblocks
 	url = https://github.com/minetest-mirrors/cblocks.git


### PR DESCRIPTION
note, this causes tests to fail for now due to https://github.com/mt-mods/dreambuilder_game/blob/master/mods/dreambuilder_test/nodenames.txt containing cool_trees node names. this i think is wanted, so that when aliases are added, the tests should pass