### PR TITLE
bump actions version to fix github nodejs 16 warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           - ghcr.io/minetest-hosting/minetest-docker:main
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: recursive


### PR DESCRIPTION
bump ci versions to avoid github warnings, soon to be fatal

will merge when/if ci passes