### PR TITLE
run test with latest engine before running automerge step

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,40 +10,52 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - name: Dependabot metadata
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: test with latest engine
+        run: docker-compose up --exit-code-from testserver
+        env:
+          ENGINE_IMAGE: "ghcr.io/minetest-hosting/minetest-docker:main"
+
+      - name: fetch metadata
         id: metadata
         uses: dependabot/fetch-metadata@v1.6.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+
       - name: Enable auto-merge for Dependabot PRs
         if: ${{
-          contains(steps.metadata.outputs.dependency-names, 'pipeworks') ||
-          contains(steps.metadata.outputs.dependency-names, 'technic') ||
-          contains(steps.metadata.outputs.dependency-names, 'homedecor_modpack') ||
-          contains(steps.metadata.outputs.dependency-names, 'home_workshop_modpack') ||
-          contains(steps.metadata.outputs.dependency-names, 'biome_lib') ||
-          contains(steps.metadata.outputs.dependency-names, 'basic_materials') ||
-          contains(steps.metadata.outputs.dependency-names, 'basic_signs') ||
-          contains(steps.metadata.outputs.dependency-names, 'blox') ||
-          contains(steps.metadata.outputs.dependency-names, 'coloredwood') ||
-          contains(steps.metadata.outputs.dependency-names, 'currency') ||
-          contains(steps.metadata.outputs.dependency-names, 'dreambuilder_hotbar') ||
-          contains(steps.metadata.outputs.dependency-names, 'gloopblocks') ||
-          contains(steps.metadata.outputs.dependency-names, 'ilights') ||
-          contains(steps.metadata.outputs.dependency-names, 'led_marquee') ||
-          contains(steps.metadata.outputs.dependency-names, 'moretrees') ||
-          contains(steps.metadata.outputs.dependency-names, 'new_campfire') ||
-          contains(steps.metadata.outputs.dependency-names, 'nixie_tubes') ||
-          contains(steps.metadata.outputs.dependency-names, 'signs_lib') ||
-          contains(steps.metadata.outputs.dependency-names, 'simple_streetlights') ||
-          contains(steps.metadata.outputs.dependency-names, 'steel') ||
-          contains(steps.metadata.outputs.dependency-names, 'street_signs') ||
-          contains(steps.metadata.outputs.dependency-names, 'travelnet') ||
-          contains(steps.metadata.outputs.dependency-names, 'unifieddyes') ||
-          contains(steps.metadata.outputs.dependency-names, 'plantlife_modpack') ||
-          contains(steps.metadata.outputs.dependency-names, 'xcompat') ||
-          contains(steps.metadata.outputs.dependency-names, 'mods/mtg')}}
-        run: gh pr merge --auto --merge "$PR_URL"
+          success() && (
+            contains(steps.metadata.outputs.dependency-names, 'pipeworks') ||
+            contains(steps.metadata.outputs.dependency-names, 'technic') ||
+            contains(steps.metadata.outputs.dependency-names, 'homedecor_modpack') ||
+            contains(steps.metadata.outputs.dependency-names, 'home_workshop_modpack') ||
+            contains(steps.metadata.outputs.dependency-names, 'biome_lib') ||
+            contains(steps.metadata.outputs.dependency-names, 'basic_materials') ||
+            contains(steps.metadata.outputs.dependency-names, 'basic_signs') ||
+            contains(steps.metadata.outputs.dependency-names, 'blox') ||
+            contains(steps.metadata.outputs.dependency-names, 'coloredwood') ||
+            contains(steps.metadata.outputs.dependency-names, 'currency') ||
+            contains(steps.metadata.outputs.dependency-names, 'dreambuilder_hotbar') ||
+            contains(steps.metadata.outputs.dependency-names, 'gloopblocks') ||
+            contains(steps.metadata.outputs.dependency-names, 'ilights') ||
+            contains(steps.metadata.outputs.dependency-names, 'led_marquee') ||
+            contains(steps.metadata.outputs.dependency-names, 'moretrees') ||
+            contains(steps.metadata.outputs.dependency-names, 'new_campfire') ||
+            contains(steps.metadata.outputs.dependency-names, 'nixie_tubes') ||
+            contains(steps.metadata.outputs.dependency-names, 'signs_lib') ||
+            contains(steps.metadata.outputs.dependency-names, 'simple_streetlights') ||
+            contains(steps.metadata.outputs.dependency-names, 'steel') ||
+            contains(steps.metadata.outputs.dependency-names, 'street_signs') ||
+            contains(steps.metadata.outputs.dependency-names, 'travelnet') ||
+            contains(steps.metadata.outputs.dependency-names, 'unifieddyes') ||
+            contains(steps.metadata.outputs.dependency-names, 'plantlife_modpack') ||
+            contains(steps.metadata.outputs.dependency-names, 'xcompat') ||
+            contains(steps.metadata.outputs.dependency-names, 'mods/mtg') )}}
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ jobs:
           - registry.gitlab.com/minetest/minetest/server:5.6.0
           - registry.gitlab.com/minetest/minetest/server:5.7.0
           - ghcr.io/minetest-hosting/minetest-docker:5.8.0
-          - ghcr.io/minetest-hosting/minetest-docker:main
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds a test with the latest engine image to the automerge workflow and should prevent merges from happening if the build fails (see: https://github.com/mt-mods/dreambuilder_game/pull/578)

I also changed the merge behavior from rebase to squash