### PR TITLE
update minetest/luanti docker image name for `5.8.0`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         ENGINE_IMAGE:
           - registry.gitlab.com/minetest/minetest/server:5.7.0
-          - ghcr.io/minetest-hosting/minetest-docker:5.8.0
+          - ghcr.io/luanti-hosting/minetest-docker:5.8.0
           - ghcr.io/minetest/minetest:5.9.0
           - ghcr.io/minetest/minetest:5.9.1
           - ghcr.io/minetest/minetest:5.10.0


### PR DESCRIPTION
ghcr doesn't do redirects it seems